### PR TITLE
Decouple InferenceSession lifecycle from Predict

### DIFF
--- a/src/Yolov5Net.App/Program.cs
+++ b/src/Yolov5Net.App/Program.cs
@@ -15,28 +15,27 @@ namespace Yolov5Net.App
 
             byte[] weights = File.ReadAllBytes("Assets/Weights/yolov5s6.onnx");
 
-            var scorer = new YoloScorer<YoloCocoP6Model>();
+            using var scorer = new YoloScorer<YoloCocoP6Model>();
 
             List<YoloPrediction> predictions = scorer.Predict(image, weights);
 
-            using (var graphics = Graphics.FromImage(image))
+            using var graphics = Graphics.FromImage(image);
+            
+            foreach (var prediction in predictions) // iterate predictions to draw results
             {
-                foreach (var prediction in predictions) // iterate predictions to draw results
-                {
-                    double score = Math.Round(prediction.Score, 2);
+                double score = Math.Round(prediction.Score, 2);
 
-                    graphics.DrawRectangles(new Pen(prediction.Label.Color, 1),
-                        new[] { prediction.Rectangle });
+                graphics.DrawRectangles(new Pen(prediction.Label.Color, 1),
+                    new[] { prediction.Rectangle });
 
-                    var (x, y) = (prediction.Rectangle.X - 3, prediction.Rectangle.Y - 23);
+                var (x, y) = (prediction.Rectangle.X - 3, prediction.Rectangle.Y - 23);
 
-                    graphics.DrawString($"{prediction.Label.Name} ({score})",
-                        new Font("Consolas", 16, GraphicsUnit.Pixel), new SolidBrush(prediction.Label.Color),
-                        new PointF(x, y));
-                }
-
-                image.Save("Assets/result.jpg");
+                graphics.DrawString($"{prediction.Label.Name} ({score})",
+                    new Font("Consolas", 16, GraphicsUnit.Pixel), new SolidBrush(prediction.Label.Color),
+                    new PointF(x, y));
             }
+
+            image.Save("Assets/result.jpg");
         }
     }
 }

--- a/src/Yolov5Net.App/Program.cs
+++ b/src/Yolov5Net.App/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using Microsoft.ML.OnnxRuntime;
 using Yolov5Net.Scorer;
 using Yolov5Net.Scorer.Models;
 
@@ -11,15 +12,12 @@ namespace Yolov5Net.App
     {
         static void Main(string[] args)
         {
-            var image = Image.FromFile("Assets/test.jpg");
-
-            byte[] weights = File.ReadAllBytes("Assets/Weights/yolov5s6.onnx");
-
-            using var scorer = new YoloScorer<YoloCocoP6Model>();
-
-            List<YoloPrediction> predictions = scorer.Predict(image, weights);
-
+            using var sessionOptions = new SessionOptions(); // Or, fe: SessionOptions.MakeSessionOptionWithCudaProvider(());
+            using var scorer = new YoloScorer<YoloCocoP6Model>("Assets/Weights/yolov5s6.onnx", sessionOptions);
+            using var image = Image.FromFile("Assets/test.jpg");
             using var graphics = Graphics.FromImage(image);
+            
+            var predictions = scorer.Predict(image);
             
             foreach (var prediction in predictions) // iterate predictions to draw results
             {

--- a/src/Yolov5Net.App/Program.cs
+++ b/src/Yolov5Net.App/Program.cs
@@ -11,9 +11,9 @@ namespace Yolov5Net.App
     {
         static void Main(string[] args)
         {
-            var image = Image.FromFile("assets/test.jpg");
+            var image = Image.FromFile("Assets/test.jpg");
 
-            byte[] weights = File.ReadAllBytes("assets/weights/yolov5s6.onnx");
+            byte[] weights = File.ReadAllBytes("Assets/Weights/yolov5s6.onnx");
 
             var scorer = new YoloScorer<YoloCocoP6Model>();
 
@@ -35,7 +35,7 @@ namespace Yolov5Net.App
                         new PointF(x, y));
                 }
 
-                image.Save("assets/result.jpg");
+                image.Save("Assets/result.jpg");
             }
         }
     }

--- a/src/Yolov5Net.App/Yolov5Net.App.csproj
+++ b/src/Yolov5Net.App/Yolov5Net.App.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Yolov5Net.App/Yolov5Net.App.csproj
+++ b/src/Yolov5Net.App/Yolov5Net.App.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Yolov5Net.Scorer/YoloScorer.cs
+++ b/src/Yolov5Net.Scorer/YoloScorer.cs
@@ -19,7 +19,7 @@ namespace Yolov5Net.Scorer
     {
         private readonly T _model;
         private readonly SessionOptions _sessionOptions;
-        private InferenceSession _inferenceSession;
+        private readonly InferenceSession _inferenceSession;
 
         /// <summary>
         /// Outputs value between 0 and 1.
@@ -107,7 +107,7 @@ namespace Yolov5Net.Scorer
         /// <summary>
         /// Runs inference session.
         /// </summary>
-        private DenseTensor<float>[] Inference(Image image, byte[] weights)
+        private DenseTensor<float>[] Inference(Image image)
         {
             Bitmap resized = null;
 
@@ -115,9 +115,7 @@ namespace Yolov5Net.Scorer
             {
                 resized = ResizeImage(image); // fit image size to specified input size
             }
-
-            _inferenceSession ??= new InferenceSession(weights, _sessionOptions ?? new SessionOptions());
-
+            
             var inputs = new List<NamedOnnxValue> // add image as onnx input
             {
                 NamedOnnxValue.CreateFromTensor("images", ExtractPixels(resized ?? image))
@@ -285,36 +283,16 @@ namespace Yolov5Net.Scorer
         /// <summary>
         /// Runs object detection.
         /// </summary>
-        public List<YoloPrediction> Predict(Image image, string weights)
+        public List<YoloPrediction> Predict(Image image)
         {
-            return Supress(ParseOutput(Inference(image, File.ReadAllBytes(weights)), image));
+            return Supress(ParseOutput(Inference(image), image));
         }
 
-        /// <summary>
-        /// Runs object detection.
-        /// </summary>
-        public List<YoloPrediction> Predict(Image image, Stream weights)
-        {
-            long length = weights.Length;
-
-            using (var reader = new BinaryReader(weights))
-            {
-                return Supress(ParseOutput(Inference(image, reader.ReadBytes((int)length)), image));
-            }
-        }
-
-        /// <summary>
-        /// Runs object detection.
-        /// </summary>
-        public List<YoloPrediction> Predict(Image image, byte[] weights)
-        {
-            return Supress(ParseOutput(Inference(image, weights), image));
-        }
-
-        public YoloScorer(SessionOptions sessionOptions = null)
+        public YoloScorer(string modelPath, SessionOptions sessionOptions = null)
         {
             _model = Activator.CreateInstance<T>();
             _sessionOptions = sessionOptions;
+            _inferenceSession = new InferenceSession(modelPath, _sessionOptions ?? new SessionOptions());
         }
 
         public void Dispose()

--- a/src/Yolov5Net.Scorer/YoloScorer.cs
+++ b/src/Yolov5Net.Scorer/YoloScorer.cs
@@ -294,6 +294,13 @@ namespace Yolov5Net.Scorer
             _sessionOptions = sessionOptions;
             _inferenceSession = new InferenceSession(modelPath, _sessionOptions ?? new SessionOptions());
         }
+        
+        public YoloScorer(byte[] model, SessionOptions sessionOptions = null)
+        {
+            _model = Activator.CreateInstance<T>();
+            _sessionOptions = sessionOptions;
+            _inferenceSession = new InferenceSession(model, _sessionOptions ?? new SessionOptions());
+        }
 
         public void Dispose()
         {

--- a/src/Yolov5Net.Scorer/Yolov5Net.Scorer.csproj
+++ b/src/Yolov5Net.Scorer/Yolov5Net.Scorer.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <Product>Yolov5Net</Product>
-        <AssemblyVersion>1.0.2.0</AssemblyVersion>
-        <FileVersion>1.0.2.0</FileVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <FileVersion>1.1.0.0</FileVersion>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Yolov5Net</PackageId>
         <Description>YOLOv5 object detection with C#, ML.NET, ONNX.</Description>
@@ -14,7 +14,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>© Mentalstack 2016-2021</Copyright>
         <Authors>Mentalstack</Authors>
-        <Version>1.0.2</Version>
+        <Version>1.1.0</Version>
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 

--- a/src/Yolov5Net.Scorer/Yolov5Net.Scorer.csproj
+++ b/src/Yolov5Net.Scorer/Yolov5Net.Scorer.csproj
@@ -15,6 +15,7 @@
         <Copyright>© Mentalstack 2016-2021</Copyright>
         <Authors>Mentalstack</Authors>
         <Version>1.0.2</Version>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
As per #8 I would like to propose some (breaking) changes to your Scorer api/package.

After this PR, the InferenceSession is only created once per YoloScorer instance. Creating a session is relative expensive and when doing a lot of inferences I would like to reuse this session. 

I've updated the constructor of the YoloScorer to take two parameters. 
- The Model, either the filename or the bytes of the model. Both are not used but fed directly into the constructor of the InferenceSession
- The SessionOptions. I need to be able to provide them to the InferenceSession, in my case I would like to be able to configure the OnnxRuntime to use CUDA. This is an optional parameter, defaulting to `new SessionOptions()`.

The YoloScorer now implements IDisposable as it owns the lifecycle of InferenceSession and SessionOptions which are IDisposable.

I've changed the paths from `assets` to `Assets` as paths are case-sensitive on Linux.

Let me know if you agree with these changes. Happy to discuss further changes.