### PR TITLE
BGR or RGB?

### DIFF
--- a/src/Yolov5Net.Scorer/YoloScorer.cs
+++ b/src/Yolov5Net.Scorer/YoloScorer.cs
@@ -99,9 +99,9 @@ namespace Yolov5Net.Scorer
 
                     for (int x = 0; x < locked.Width; x++)
                     {
-                        tensor[0, 0, y, x] = row[x * 3 + 0] / 255.0F;
+                        tensor[0, 0, y, x] = row[x * 3 + 2] / 255.0F;
                         tensor[0, 1, y, x] = row[x * 3 + 1] / 255.0F;
-                        tensor[0, 2, y, x] = row[x * 3 + 2] / 255.0F;
+                        tensor[0, 2, y, x] = row[x * 3 + 0] / 255.0F;
                     }
                 }
 


### PR DESCRIPTION
I might be wrong here but isn't Yolo trained to be working with BGR instead of RGB? I got much better results after this change than before. I ran into this when working with a model that had to be able to distinct red from blue objects and got very where inference results with the .NET core (while the python inference performed fine)... 

Looking forward to your views/experiences.